### PR TITLE
feat: trace Phoenix LiveView render

### DIFF
--- a/instrumentation/opentelemetry_phoenix/lib/opentelemetry_phoenix.ex
+++ b/instrumentation/opentelemetry_phoenix/lib/opentelemetry_phoenix.ex
@@ -123,6 +123,9 @@ defmodule OpentelemetryPhoenix do
         [:phoenix, :live_view, :handle_event, :start],
         [:phoenix, :live_view, :handle_event, :stop],
         [:phoenix, :live_view, :handle_event, :exception],
+        [:phoenix, :live_view, :render, :start],
+        [:phoenix, :live_view, :render, :stop],
+        [:phoenix, :live_view, :render, :exception],
         [:phoenix, :live_component, :handle_event, :start],
         [:phoenix, :live_component, :handle_event, :stop],
         [:phoenix, :live_component, :handle_event, :exception]
@@ -183,6 +186,20 @@ defmodule OpentelemetryPhoenix do
     OpentelemetryTelemetry.start_telemetry_span(
       @tracer_id,
       "#{inspect(live_view)}.handle_params",
+      meta,
+      %{kind: :server}
+    )
+  end
+
+  def handle_liveview_event(
+        [:phoenix, _live, :render, :start],
+        _measurements,
+        %{socket: %{view: live_view}} = meta,
+        _handler_configuration
+      ) do
+    OpentelemetryTelemetry.start_telemetry_span(
+      @tracer_id,
+      "#{inspect(live_view)}.render",
       meta,
       %{kind: :server}
     )


### PR DESCRIPTION
It seems these events are not traced because Phoenix LiveView started emitting these events (https://github.com/phoenixframework/phoenix_live_view/pull/2907) a few months after the liveview integration was done here in OpenTelemetryPhoenix (https://github.com/open-telemetry/opentelemetry-erlang-contrib/pull/198).

Anyway, adding, so they are traced and anything downstream the render has the proper parent span linking.